### PR TITLE
Check class constraints

### DIFF
--- a/configuration/settings.lisp
+++ b/configuration/settings.lisp
@@ -29,3 +29,7 @@
 (defparameter *supply-cache-headers-p* nil
   "when non-nil, cache headers are supplied.  this works together with mu-cache.")
 
+(defparameter *check-classes-p* nil
+  "TODO: STILL UNUSED
+   when non-nil, all operations related to relations are done with ld classes in mind.
+   otherwise only the preditace name is taken into account.")

--- a/framework/call-implementation.lisp
+++ b/framework/call-implementation.lisp
@@ -85,7 +85,7 @@
       (cache-clear-class resource)
       (let* ((jsown:*parsed-null-value* :null)
              (json-input (jsown:parse (post-body)))
-             (uuid (mu-support:make-uuid)) 
+             (uuid (mu-support:make-uuid))
              (resource-uri (format nil "~A~A"
                                    (raw-content (ld-resource-base resource))
                                    uuid))
@@ -504,6 +504,11 @@
       (values (item-spec-to-jsown (first data-item-specs))
               (mapcar #'item-spec-to-jsown included-item-specs)))))
 
+(defun retrieve-relation-class-constraint (link)
+  (ld-class (find-resource-by-name (resource-name link)))
+)
+
+
 (defgeneric build-relationships-object (item-spec link)
   (:documentation "Returns the content of one of the relationships based
    on the type of relation, and whether or not the relationship should
@@ -648,9 +653,11 @@
                                :sparql-body (format nil
                                                     (s+ "~A ~{~A~,^/~} ?resource. "
                                                         "?resource mu:uuid ?uuid. "
+                                                        "?resource a ~A"
                                                         "~@[~A~] ")
                                                     resource-url
                                                     (ld-property-list link)
+                                                    (retrieve-relation-class-constraint link)
                                                     (authorization-query resource :show resource-url))
                                :source-variable (s-var "resource")
                                :resource (referred-resource link))
@@ -677,9 +684,11 @@
             (first (sparql:select (s-var "uuid")
                                   (format nil (s+ "~A ~{~A~,^/~} ?resource. "
                                                   "?resource mu:uuid ?uuid. "
+                                                  "?resource a ~A"
                                                   "~@[~A~] ")
                                           resource-url
                                           (ld-property-list link)
+                                          (retrieve-relation-class-constraint link)
                                           (authorization-query item-spec :show resource-url)))))
            (linked-resource (resource-name (referred-resource link))))
       (and query-results
@@ -692,9 +701,11 @@
             (sparql:select (s-var "uuid")
                            (format nil (s+ "~A ~{~A~,^/~} ?resource. "
                                            "?resource mu:uuid ?uuid. "
+                                           "?resource a ~A"
                                            "~@[~A~] ")
                                    resource-url
                                    (ld-property-list link)
+                                   (retrieve-relation-class-constraint link)
                                    (authorization-query item-spec :show resource-url))))
            (linked-resource (resource-name (referred-resource link))))
       (loop for uuid in (jsown:filter query-results map "uuid" "value")

--- a/framework/resource-model.lisp
+++ b/framework/resource-model.lisp
@@ -49,17 +49,21 @@
                                                   (mapcar (lambda (prop)
                                                             (format nil "~A" (s-inv prop)))
                                                           (ld-property-list link)))))
-      inverse-property-list
       ;; find inverse relationship
       (dolist (inverse-link (all-links linked-resource))
-        (when (equalp inverse-property-list
-                      (mapcar (lambda (prop) (format nil "~A" prop))
-                              (ld-property-list inverse-link)))
-          ;; we have found an inverse relationship of ours
-          (push `(:resource ,resource :link ,link)
-                (inverse-links inverse-link))
-          (push `(:resource ,linked-resource :link ,inverse-link)
-                (inverse-links link)))))))
+        (let ((linked-inverse-property-list (mapcar (lambda (prop) (format nil "~A" prop))
+                (ld-property-list inverse-link))))
+          (when (and  (equalp ; predicate must be equal
+                              inverse-property-list
+                              linked-inverse-property-list)
+                      (equalp ; types must match as well
+                              (resource-name resource)
+                              (resource-name inverse-link)))
+                ;; we have found an inverse relationship of ours
+                (push `(:resource ,resource :link ,link)
+                      (inverse-links inverse-link))
+                (push `(:resource ,linked-resource :link ,inverse-link)
+                      (inverse-links link))))))))
 
 (defgeneric authorization-token (resource operation)
   (:documentation "Yields the authorization token which grants


### PR DESCRIPTION
Already implemented:
- Class constraints are checked when looking for inverses to build the resource model
- Class constraints in retrieval sparql queries

To do:
- Class constraints in delete-where sparql updates
- Make optional with check-classes-p parameter
- Support for polymorphism ;) 