### PR TITLE
Add option for explicit rdf:type declarations

### DIFF
--- a/configuration/settings.lisp
+++ b/configuration/settings.lisp
@@ -29,3 +29,7 @@
 (defparameter *supply-cache-headers-p* nil
   "when non-nil, cache headers are supplied.  this works together with mu-cache.")
 
+(defparameter *declare-resource-types-p*
+  (let ((env (uiop:getenv "MU_DECLARE_RESOURCE_TYPES")))
+    (and env (or (equal "true" env) (equal env "TRUE"))))
+  "when true, explicitly declare rdf:type for all resources in property and relation queries.")


### PR DESCRIPTION
Sometimes it's useful to have rdf:types explicitly declared in
property and relation queries. This is implemented, and can be
turned on using the parameter *declare-resource-types-p*.