### PR TITLE
Fix invalid SPARQL expression in uuid pagination query

### DIFF
--- a/framework/response-generation.lisp
+++ b/framework/response-generation.lisp
@@ -56,7 +56,7 @@
     ;; between having to sort (order-info) and not having
     ;; to sort.  some logic is shared.
     (let ((sparql-variables (if order-info
-                                (format nil "DISTINCT ~A~{ ~{MAX(~A) AS ~A~}~}"
+                                (format nil "DISTINCT ~A~{ ~{(MAX(~A) AS ~A)~}~}"
                                         (s-var "uuid") (mapcar (lambda (a) (list a a)) order-variables))
                                 (format nil "DISTINCT ~A" (s-var "uuid"))))
           (sparql-body (if order-info


### PR DESCRIPTION
Although it's accepted by Virtuoso, technically `MAX(?__name1) AS ?__name1` is
invalid SPARQL, since it omits the surrounding parentheses. The select clause
should be `SELECT DISTINCT ?uuid (MAX(?__name1) AS ?__name1)`.