### PR TITLE
Documentation for domain.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # JSONAPI to SPARQL, and back
 
-mu-cl-resources provides a [JSONAPI](http://jsonapi.org) compatible interface to the content specified in the configuration.  Most configuration occurs in the configuration/domain.lisp file, an example of which can be found in this repository.
+mu-cl-resources provides a [JSONAPI](http://jsonapi.org) compatible interface to the content specified in the configuration.  Most configuration occurs in the configuration/domain.json or configuration/domain.lisp file (your choice), an examples of which can be found in this repository.
 
-Most configuration happens in the domain.lisp file.  See `configuration/domain.lisp` for an example.  This file defines the glue between the JSON world and the RDF world.  When defining a model, be sure to have a good idea on what both worlds will look like.
+Most configuration happens in the domain file.  See `configuration/domain.json` and `configuration/domain.lisp` for an introduction.  This file defines the glue between the JSON world and the RDF world.  When defining a model, be sure to have a good idea on what both worlds will look like.
 
 The documentation offered here is not exhaustive.  This component handles a wide variety of use-cases and has support for esotheric features for experimentation, which may land in the core at a later time.  As such, some features which the component offers are not documented in this readme.
+
+The domain.json format is still growing, some configuration parameters can only be set in the lisp variant.  You can combine both formats, see Tutorial: Combining domain.lisp and domain.json.
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ mu-cl-resources is driven from the domain.json file.  This file describes the co
 
 
 #### /configuration/domain.json
-The domain.lisp contains resource definitions for each resource type in the application.  These resource definitions provide a three-way connection:
+The domain.json contains resource definitions for each resource type in the application.  These resource definitions provide a three-way connection:
 
-  - It names things to make connections within the domain.lisp file
+  - It names things to make connections within the domain.json file
   - It describes the properties as seen through the json api
   - It describes the semantic model used in order to implement the json api
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,37 @@ The domain.json format is still growing, some configuration parameters can only 
 
 ## Tutorials
 
+### Add mu-cl-resources to a stack
+Add the following snippet to the services block of your `docker-compose.yml`:
+
+```yml
+services:
+  resource:
+    image: semtech/mu-cl-resources:1.18.0
+    links:
+      - db:database
+    volumes:
+      - ./config/resources:/config
+```
+
+Next, copy the configuration files from the `examples/` folder in this repository inside the `./config/resources` folder of your project. You have to copy either the JSON configuration file `examples/domain.json` or the Lisp configuration files `examples/domain.lisp` and `examples/repository.lisp`.
+
+Finally, add a new rule to the dispatcher configuration of your project in `./config/dispatcher/dispatcher.ex` to forward requests to `/themes` to the new resource service:
+```yml
+  get "/themes/*path", @any do
+    forward conn, path, "http://resource/themes/"
+  end
+```
+
+Start your stack running `docker-compose up -d`. Assuming the identifier is published on port 80, sending a request to http://localhost/themes should return an empty array coming from mu-cl-resources.
+
+Since it is common for a mu.semte.ch project to contain mu-cl-resources, the default blueprint for a mu.semte.ch project, [mu-semtech/mu-project](https://github.com/mu-semtech/mu-project), contains mu-cl-resources.
+
+### Introduction to a configuration through domain.lisp
 This service is driven from the domain.lisp file which you should adapt to describe your domain.  In this section we briefly describe how everything is wired together, and how you can quickly get an API up and running.
 
 mu-cl-resources is driven from the domain.lisp file.  This file describes the connection between the JSONAPI and the semantic model.  Secondly, there is the repository.lisp file, in which you can define new prefixes to shorten your domain description.  This repository contains an example of both files in the configuration folder.
 
-### Setup in mu.semte.ch project
-
-It is common for a mu.semte.ch project to contain mu-cl-resources.  The default blueprint for a mu.semte.ch project, [mu-semtech/mu-project](https://github.com/mu-semtech/mu-project), contains mu-cl-resources.  Furthermore, there is an example written to config/domain.lisp.  This is where we will apply our changes.  Secondly, there is the repositories.lisp, in which you can change add prefixes to use in your domain specification.  If you're setting up mu-cl-resources in a mu.semte.ch project, be sure to check out the documentation of the dispatcher to ensure mu-cl-resources receives your queries.
-
-### Introduction to a configuration through domain.lisp
 #### /configuration/domain.lisp
 
 The domain.lisp contains resource definitions for each file in the application.  These resource definitions provide a three-way connection:

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Each resource definition is a combination of these three views.  Let us assume a
           "type": "string",
           "predicate": "http://xmlns.com/foaf/0.1/name"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/people/"
     }
   }
@@ -229,7 +229,7 @@ Assuming the `foaf` prefix is defined, we can make this example slightly easier 
           "type": "string",
           "predicate": "foaf:name"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/people/"
     }
   }
@@ -258,7 +258,7 @@ We can insert multiple attributes if desired. We can update our example to also 
           "type": "number",
           "predicate": "foaf:age"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/people/"
     }
   }
@@ -284,7 +284,7 @@ Most resources link to other resources.  Let's first define a second resouce, an
           "type": "string",
           "predicate": "foaf:accountName"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/accounts/"
     }
   }
@@ -317,7 +317,7 @@ The definition of this `account` resource is very similar to that of the `person
           "target": "account",
           "cardinality": "many"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/people/"
     },
     "accounts": {
@@ -328,7 +328,7 @@ The definition of this `account` resource is very similar to that of the `person
           "type": "string",
           "predicate": "foaf:accountName"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/accounts/"
     }
   }
@@ -360,7 +360,7 @@ How about getting the person which links to this account.  There is only a singl
           "cardinality": "one",
           "inverse": true
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/accounts/"
     }
   }
@@ -395,7 +395,7 @@ The complete setup of our user and account looks as follows:
           "target": "account",
           "cardinality": "many"
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/people/"
     },
     "accounts": {
@@ -414,7 +414,7 @@ The complete setup of our user and account looks as follows:
           "cardinality": "one",
           "inverse": true
         }
-      }
+      },
       "new-resource-base": "https://my-application.com/accounts/"
     }
   }

--- a/README.md
+++ b/README.md
@@ -444,6 +444,20 @@ More information on each of these calls can be found throughout this document.
 #### More configuration options
 Configuration of the complete mu-cl-resource instance can only be done using a configuration file in Lisp.
 
+### How to spread the domain configuration across multiple files
+For larger applications with a broad domain, defining all resources in one domain file may become clumsy and confusing. Mu-cl-resources supports spreading your domain definitions across multiple files. The root domain files must be in Lisp format, but the included files may be in Lisp or JSON format.
+
+To include additional files in your domain configuration, add `read-domain-file` statements on top of the `domain.lisp` file.
+
+```lisp
+(in-package :mu-cl-resources)
+
+(read-domain-file "users.json")
+(read-domain-file "publications.lisp")
+```
+
+Restart the service. The additional configuration files will be picked up by mu-cl-resources.
+
 ## Reference
 ### Defining resources in Lisp
 As the integration with the frontend data-store is handled automatically, most of your time with mu-cl-resources will be spent configuring resources.  This overview provides a non-exhaustive list of the most common features of mu-cl-resources.

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The definition of this `account` resource is very similar to that of the `person
 
 The `relationships` object specifies that a `person` may link to many resources of target type `account`.  In the triplestore, the link can be found by following the [foaf:account](http://xmlns.com/foaf/0.1/account) predicate, originating from the person's URI.  This relationship is exposed to the JSON API by using the relationship name "accounts".  Hence a GET to `/people/42/accounts` would yield the accounts of the person with UUID 42.
 
-How about getting the person which links to this account.  There is only a single person connected to an account.  Hence we can specify a relationship with cardinality `"one"` on the `account` resource.  In the semantic model of the triplestore, the relationship uses the [foaf:account](http://xmlns.com/foaf/0.1/account) property going from the person to the account.  Finding the person for an account therefore means we have to follow the same relationship in the other direction.  We can add the property `"inverse": true` to any relationship to make the semantic model follow the inverse arrow.  Here, the key in the json body will be `owner` rather than person.
+How about getting the person which links to this account.  There is only a single person connected to an account.  Hence we can specify a relationship with cardinality `one` on the `account` resource.  In the semantic model of the triplestore, the relationship uses the [foaf:account](http://xmlns.com/foaf/0.1/account) property going from the person to the account.  Finding the person for an account therefore means we have to follow the same relationship in the other direction.  We can add the property `"inverse": true` to any relationship to make the semantic model follow the inverse arrow.  Here, the key in the json body will be `owner` rather than person.
 
 ```javascript
 {
@@ -442,7 +442,7 @@ We intend to support the full spec of [JSONAPI](http://jsonapi.org).  Support fo
 More information on each of these calls can be found throughout this document.
 
 #### More configuration options
-Configuration of the complete mu-cl-resource instance can only be done using a configuration file in Lisp.
+Configuration of the complete mu-cl-resource instance can only be done using a configuration file in Lisp. See Tutorial: Configuring settings using a domain.json file.
 
 ### Combining domain.lisp and domain.json
 For larger applications with a broad domain, defining all resources in one domain file may become clumsy and confusing. Mu-cl-resources supports spreading your domain definitions across multiple files. The root domain files must be in Lisp format, but the included files may be in Lisp or JSON format.
@@ -457,6 +457,22 @@ To include additional files in your domain configuration, add `read-domain-file`
 ```
 
 Restart the service. The additional configuration files will be picked up by mu-cl-resources.
+
+### Configuring settings using a domain.json file
+Most settings can only be configured in Lisp format. This tutorial describes how to configure the settings if you defined your resources using a `domain.json` file.
+
+First create a `domain.lisp` file next to the existing `domain.json` file.
+
+Next, add the following contents to the `domain.lisp` file:
+```
+(in-package :mu-cl-resources)
+
+(read-domain-file "domain.json")
+```
+
+Add your settings in `domain.lisp`.
+
+Restart the service. The newly configured settings will be picked up by mu-cl-resources.
 
 ## Reference
 ### Defining resources in Lisp

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ More information on each of these calls can be found throughout this document.
 #### More configuration options
 Configuration of the complete mu-cl-resource instance can only be done using a configuration file in Lisp.
 
-### How to spread the domain configuration across multiple files
+### Combining domain.lisp and domain.json
 For larger applications with a broad domain, defining all resources in one domain file may become clumsy and confusing. Mu-cl-resources supports spreading your domain definitions across multiple files. The root domain files must be in Lisp format, but the included files may be in Lisp or JSON format.
 
 To include additional files in your domain configuration, add `read-domain-file` statements on top of the `domain.lisp` file.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ mu-cl-resources is driven from the domain.lisp file.  This file describes the co
 
 It is common for a mu.semte.ch project to contain mu-cl-resources.  The default blueprint for a mu.semte.ch project, [mu-semtech/mu-project](https://github.com/mu-semtech/mu-project), contains mu-cl-resources.  Furthermore, there is an example written to config/domain.lisp.  This is where we will apply our changes.  Secondly, there is the repositories.lisp, in which you can change add prefixes to use in your domain specification.  If you're setting up mu-cl-resources in a mu.semte.ch project, be sure to check out the documentation of the dispatcher to ensure mu-cl-resources receives your queries.
 
-### /configuration/domain.lisp
+### Introduction to a configuration through domain.lisp
+#### /configuration/domain.lisp
 
 The domain.lisp contains resource definitions for each file in the application.  These resource definitions provide a three-way connection:
 
@@ -116,13 +117,13 @@ The complete setup of our user and account looks as follows:
       :resource-base (s-url "http://my-application.com/accounts/")
       :on-path "accounts")
 
-### /configuration/repositories.lisp
+#### /configuration/repositories.lisp
 
 The previous example used the foaf prefix in order to denote classes and properties.  The `/configuration/repositories.lisp` allows you to specify your own prefixes to use in your definitions.  A good source for commonly used abbreviations is [prefix.cc](https://prefix.cc).
 
     (add-prefix "foaf" "http://xmlns.com/foaf/0.1/")
 
-### Resulting API
+#### Resulting API
 We intend to support the full spec of [JSONAPI](http://jsonapi.org).  Support for this API comes out of the box with frameworks such as [ember-data](https://github.com/emberjs/data).  Most of what you read there will work, errors being a notable exception.  Here, we list some common calls which you could execute using the resources specified above.
 
   - `# GET /people`
@@ -142,7 +143,7 @@ We intend to support the full spec of [JSONAPI](http://jsonapi.org).  Support fo
 
 More information on each of these calls can be found throughout this document.
 
-### More configuration options
+#### More configuration options
 
 The complete mu-cl-resources instance, a specific resource, as well as a property can have options set to override the default behaviour.
 
@@ -150,9 +151,13 @@ The complete mu-cl-resources instance, a specific resource, as well as a propert
   - *resource specific options:* The keyword `:features` at the same level as the `:class` may specify options which alter the behaviour of the specific resource.
   - *property options:* Symbols following the definition of a single property may give mu-cl-resources extra information on how the property will be used.
 
-## Reference
-### Defining resources
+### Introduction to a configuration through domain.json
+#### /configuration/domain.json
+#### Resulting API
+#### More configuration options
 
+## Reference
+### Defining resources in Lisp
 As the integration with the frontend data-store is handled automatically, most of your time with mu-cl-resources will be spent configuring resources.  This overview provides a non-exhaustive list of the most common features of mu-cl-resources.
 
 Each defined resource is specified by the `define-resource` construction.  An example could look like this:
@@ -236,6 +241,9 @@ The format of a single value consists of the internal name of the resource to be
   - *`:via`* Contains the URI of the RDF property by which the related objects can be found.
   - *`:as`* Contains the attribute in the JSON API.
   - *`:inverse`* Optional, when set to `t` it inverses the direction of the relationship supplied in `:via`.
+
+### Defining resources in JSON
+TODO
 
 ### Querying the API
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Most configuration happens in the domain.lisp file.  See `configuration/domain.l
 
 The documentation offered here is not exhaustive.  This component handles a wide variety of use-cases and has support for esotheric features for experimentation, which may land in the core at a later time.  As such, some features which the component offers are not documented in this readme.
 
-## Brief hands-on overview
+## Tutorials
 
 This service is driven from the domain.lisp file which you should adapt to describe your domain.  In this section we briefly describe how everything is wired together, and how you can quickly get an API up and running.
 
@@ -148,7 +148,8 @@ The complete mu-cl-resources instance, a specific resource, as well as a propert
   - *resource specific options:* The keyword `:features` at the same level as the `:class` may specify options which alter the behaviour of the specific resource.
   - *property options:* Symbols following the definition of a single property may give mu-cl-resources extra information on how the property will be used.
 
-## Defining resources
+## Reference
+### Defining resources
 
 As the integration with the frontend data-store is handled automatically, most of your time with mu-cl-resources will be spent configuring resources.  This overview provides a non-exhaustive list of the most common features of mu-cl-resources.
 
@@ -171,7 +172,7 @@ Each defined resource is specified by the `define-resource` construction.  An ex
 
 We will use this example to explain how various features in mu-cl-resources work.
 
-### Overview of keys
+#### Overview of keys
 
 Each call to `define-resource` starts out with the name of the resource (used when referring to the resource internally), a set of empty parens (for future use), and a set of key-value pairs.  This section gives a brief overview of the valid keys, and what their use is.
 
@@ -183,7 +184,7 @@ Each call to `define-resource` starts out with the name of the resource (used wh
   - *`:resource-base`* An `s-url` containing the prefix for the URI used when creating new resources.
   - *`:on-path`* The path on which the resource is supplied, this corresponds to the `type` property in the JSON body.  JSONAPI advises to use the plural form here.
 
-### Simple properties
+#### Simple properties
 
 The properties section in the mu-cl-resources configuration corresponds to the attributes in the JSON payload.  This section describes how to set properties.
 
@@ -215,7 +216,7 @@ A wide set of types is supported.  Extensions are necessary in order to implemen
   - *g-year* Experimental: A specific representation of a year
   - *geometry* Experimental: A geometry-string in a format your triplestore understands
 
-### Relationships
+#### Relationships
 
 Relationships are split into single value `:has-one` and multiple value `:has-many` relationships.  In both cases, having a value is optional.
 
@@ -234,7 +235,7 @@ The format of a single value consists of the internal name of the resource to be
   - *`:as`* Contains the attribute in the JSON API.
   - *`:inverse`* Optional, when set to `t` it inverses the direction of the relationship supplied in `:via`.
 
-## Querying the API
+### Querying the API
 
 mu-cl-resources provides extensive support for searching and filtering through results.  A notable exception is fuzzy text search as that is not a built-in for standard SPARQL.
 
@@ -268,7 +269,7 @@ We will mostly base ourselves on the example which was previous supplied.
 
 Various resources have not been defined in our example.  `location` and `document` are left as an exercise to the reader.
 
-### Basic filtering
+#### Basic filtering
 
 Basic searching is done by using the `?filter` query parameter.  We can search for "John Doe" in any key of our `person` by sending
 
@@ -284,7 +285,7 @@ All of these searches are case-insensitive, and they search for any field which 
 
 All filter modifiers start with a colon (:) followed by the name of the filter, followed by a configuration parameter.  This specific filter will search for a name with exactly "John Doe" in its contents.  No more, no less.
 
-### Filtering relationships
+#### Filtering relationships
 
 Filters can also be scoped to relationships.  JSONAPI guarantees that attributes and relationships will never share a name.  Hence we can use the same syntax as we used to identify an attribute in order to identify a relationship.
 
@@ -300,7 +301,7 @@ We can add more filters as we please.  We can search for all documents belonging
 
 This will return all documents belonging to anyone named John in an account named exactly `Dropbox`.
 
-### Sorting
+#### Sorting
 
 Sorting is specified in [JSONAPI](http://jsonapi.org/format/#fetching-sorting) somewhat more extensively.  What is specified there works, but is augmented to sorting by relationships.
 
@@ -316,7 +317,7 @@ Sorting by relationships allows us to sort accounts by the name of their owner
 
     GET /accounts?sort=owner.name
 
-### Filtering on exact relationships
+#### Filtering on exact relationships
 
 Objects in JSONAPI are identified by their type and their identifier.  To find all objects that link to another object through some relationship, we can use this feature.
 
@@ -330,7 +331,7 @@ This pattern becomes more intersting when we start searching for more than one d
 
 This filter can be combined with the other filters to provide very extensive search interfaces.
 
-### Special filters
+#### Special filters
 
 Aside from regular text searches, a set of custom filters have been added.  These filters are the last component of a search, and are easy to identify as they start with a colon (:).  Following is a brief list of filters which exist.  This list may be extended over time.
 
@@ -356,7 +357,7 @@ Aside from regular text searches, a set of custom filters have been added.  Thes
 
 - *:has:* The inverse of `:has-no:` forces the relationship to exist.  Syntax may be subject to change.
 
-### Including results
+#### Including results
 
 There exists an optional part of [the JSONAPI spec](http://jsonapi.org/format/#fetching-includes) which handles the inclusion of related resources.  It specifies how you can request resources related to your response so you don't have to make too many calls to the server.
 
@@ -378,7 +379,7 @@ We can also include the location if we'd want to render that too:
 
 Combining included results with filters makes for a very powerful API.  Note that including results does require more queries to be sent to the database.
 
-### Pagination
+#### Pagination
 
 Pagination is also included in [the JSONAPI spec](http://jsonapi.org/format/#fetching-pagination).  All resources have it enabled by default.  We support the `page[number]` and `page[size]` variant.
 
@@ -415,7 +416,7 @@ If you want mu-cl-resources to yield the total amount of results in the `meta` p
     (defparameter *include-count-in-paginated-response* t)
 
 
-### Sparse fieldsets
+#### Sparse fieldsets
 
 Sparse fieldsets is also [a feature of JSONAPI](http://jsonapi.org/format/#fetching-sparse-fieldsets).  If your model has many attributes, but you do not intend to render them on the frontend, you can opt out of fetching them.  Use the `fields` query parameter to fetch only the necessary results.
 
@@ -432,13 +433,13 @@ You can add filters to ensure we only get authors of papers aged over 42 which h
     GET /people?filter[accounts][:exact:name]=Dropbox&filter[:gt:age]=42&filter[:has:publication]=true&include=publications
 
 
-## Caching
+### Caching
 
 Efficient caching is a complex story.  mu-cl-resources ships with support for two levels of caching: an internal cache which can keep track of object properties and counts, and an external cache which can cache complete queries.
 
 Both of these caches are subject to change in their implementation, but the end-user API should stay the same.
 
-### Internal cache
+#### Internal cache
 
 In order to opt in to the internal model caching, set `*cache-model-properties*` to `t`.  Note that this currently assumes mu-cl-resources is the only service altering the resources.
 
@@ -450,7 +451,7 @@ Separate from this, you can choose to also cache the count queries.  On very lar
 
 Note: mu-cl-resources does not clear its internal caches when external services update the semantic model without wiring.  See below for wiring the delta-notifier.
 
-### External cache
+#### External cache
 
 Caching requests is more complex for a JSONAPI than for a web page.  A single update may invalidate a wide range of pages, but it should not invalidate too many pages.  As such, we've written a separate cache for JSONAPI-like bodies.  Find it at [mu-semtech/mu-cache](https://github.com/mu-semtech/mu-cache).
 
@@ -460,20 +461,20 @@ In order to enable the external cache, you have to set the `*supply-cache-header
 
 Note: mu-cl-resources speaks the protocol of this cache, but does not update the cache when external resources update the semantic model without see below for wiring the delta-notifier.
 
-### Cache clearing with delta-notifier
+#### Cache clearing with delta-notifier
 
 mu-cl-resources has multiple levels of caching and can update these when it updates the model in the database.  when external services update the semantic model, mu-cl-resources needs to be informed about these changes so it can correctly clear the caches it maintains.
 
 In order for cache clearing to work, delta's need to be received.  This requires setting up mu-authorization and delta-notifier to receive the delta's.  mu-authorization needs to be configured so it sends raw delta messages to the delta-notifier.  The delta-notifier needs to be configured so it forwards the correct format to mu-cl-resources.  mu-cl-resources needs to be wired to the mu-cache so it can clear those caches when changes arrive.
 
-#### Configuring mu-authorization and wiring to delta-notifier
+##### Configuring mu-authorization and wiring to delta-notifier
 
 mu-authorization handles security for most calls in your backend and creates delta messages for all updated triples.  See the [mu-semtech/mu-authorization readme](https://github.com/mu-semtech/mu-authorization) for information on how to set up this security layer.
 
 The delta-notifier can send messages to various entities to update their internal caches.  See [mu-semtech/delta-notifier readme](https://github.com/mu-semtech/delta-notifier) for more information on how to add the delta-notifier to your stack.
 
 
-#### Wiring the delta-notifier, mu-cache, and mu-cl-resources
+##### Wiring the delta-notifier, mu-cache, and mu-cl-resources
 
 In the following setup we assume a few names.  `resourcebackend` is the name for the mu-cl-resources component, `resourcecache` is the name for the mu-cl-resources cache.  Update the examples so they match your use-case.
 
@@ -530,9 +531,25 @@ To ensure mu-cl-resources sends its updates back to the resourcecache, it needs 
         CACHE_CLEAR_PATH: "http://resourcecache/.mu/clear-keys"
 ```
 
-## Features to be documented
+## Discussions
+### Why this component?
+This component is in use in a great deal of mu.semte.ch stacks.  A high-level picture as to why we built this component, and how it fits in the architecture, is suiting.
 
-### Authorization
+The idea of mu-cl-resources is to provide an API which can easily be consumed by frontend applications.  The most common calls which a backend offers are repetitive and boring to implement.  Good developers should not be bothered with these boring details.  Instead, a declarative configuration can get rid of all of this.
+
+Furthermore, the wide reuse of this component provides us with a rich shared code-base.  The wide use of the code-base allows us to unlock an enormous amount of shared value by implementing small features in this codebase.  On the flipside, we should take great care that this repository does not get out of hand, as that may impact many applications.
+
+### Is this a microservice?
+
+Much of the code needed to implement this component was written specifically for this component.  It can be argued that this component is therefore not a typical microservice component.  We would argue differently.
+
+From a consumer's perspective, the configuration supplied of mu-cl-resources is the relevant portion of this service.  The API which is offered may be broad, but the configuration to maintain is comparatively small.  As the consumer has a good overview of the code necessary to configure this service, this could be considered a microservice from the consumer's perspective.
+
+From the developer's perspective things may look different.  It is clear that mu-cl-resources quite a broad code base.  Replacing it with other components has proven to be more expensive than expected.  Although this holds, many of the used functions could (and should) be abstracted into separate libraries over time.  Furthermore, we expect a similar code-base to work in different languages, although more code may need to be written.
+
+### Features to be documented
+
+#### Authorization
 
 The current implementation of mu-cl-resources ships with an extensive authorization model.  This model is being revized as we aim to cut authorization out of the microservices and convert it into a layer on top of the SPARQL endpoint.  Thereby abstracting authorization and ensuring it is configured correctly throughout the whole stack.
 
@@ -547,17 +564,17 @@ Current configuration follows a model which has a grant token on a per-object ba
 
 We do not document this in depth as support for this is only useful at this time.
 
-### Using different sparql stores
+#### Using different sparql stores
 
 The default connector assumes you'll connect to a Virtuoso endpoint.  However, this is not a requirement.  By adding the necessary content into the dependencies folder, you can choose to enable a different store.  This may mock specific details of the store, such as wrapping incorrect results or choosing a different connector point.  An example of this can be found at [madnificent/cl-fuseki-blazegraph-plugin](https://github.com/madnificent/cl-fuseki-blazegraph-plugin)
 
-### Generators
+#### Generators
 
 There are a few applications which build on top of mu-cl-resources to generate meaningful content.
 
 One example is the mu-application-generator which scaffolds an resource editing application based on your API, another is [mu-semtech/cl-resources-openapi-generator](https://github.com/mu-semtech/cl-resources-openapi-generator).
 
-### Configuration parameters
+#### Configuration parameters
 
 There are a wider set of configuration parameters which allow you to configure mu-cl-resources to your liking.  Including enabling experimental features.  Many of these are currently not documented, most can be found in the release notes.  Following is a set of the configuration options.
 
@@ -569,18 +586,18 @@ You con configure an option by calling `(setf property-name value)` after the `i
     (setf *verify-accept-header* nil)
 
 
-#### Content and accept types
+##### Content and accept types
 
 The content-type and accept type should be validated as per jsonapi.org specification.  Due to historic reasons, the ACCEPT type is not checked by default, whereas the CONTENT-TYPE is checked on update/create requests.  Following parameters allow for configuration.
 
 - *`*verify-accept-header*`* _[default: nil]_ Validation on the ACCEPT header to contain application/vndi+json.
 - *`*verify-content-type-header*`* _[default: t]_ Validation on the CONTENT-TYPE header to contain application/vndi+json.
 
-#### Logging
+##### Logging
 
 mu-cl-resources can log queries and delta messages which should be cleared by the cache.
 
-##### Queries
+###### Queries
 
 mu-cl-resources logs all queries by default.  You can configure which queries should be logged by setting the `sparql:*query-log-types*` provided by the cl-fuseki library.  The parameter should be an array with (some of) the following keywords or `nil` for no logging.
 
@@ -594,21 +611,21 @@ An example configuration to only log known update queries and known ask queries 
 
     `(defparameter *sparql:*query-log-types* '(:update :ask))`
 
-##### Delta-based cache clearing
+###### Delta-based cache clearing
 
 The cache of the delta service can be cleared by wiring the delta-notifier to mu-cl-resources.  mu-cl-resources will only clear the me-cache if cache-keys are being sent.  The clear-keys which mu-cl-resources sends to the mu-cache on delta messages can be configured by setting the `*log-delta-clear-keys*` to a non-nil value.
 
      (setf *log-delta-clear-keys* t)
 
 
-#### Pagination
+##### Pagination
 
 Pagination is described separately above.  Not that included resources are never paginated.  Both the default page size, as well as the amount of available results can be returned.
 
 - *`*default-page-size*`* _[default: 20]_ Sets the default page size.
 - *`*include-count-in-paginated-responses*`* _[default: nil]_ Adds the amount of available results in the meta object of the response.
 
-#### Caching
+##### Caching
 
 See the separate section on caching.  Following properties can be configured:
 
@@ -617,27 +634,9 @@ See the separate section on caching.  Following properties can be configured:
 - *`*cache-count-queries-p*` * _[default: nil]_ Cache result of count queries internally if set to t.
 - *`*cache-clear-path*`* _[default: nil]_ If set and deltas are received, cache clear keys will be sent to this endpoint.
 
-### Separate domain.lisp files
+#### Separate domain.lisp files
 
 The domain.lisp file exists in multiple formats.  As such, experimental drafts in json also exist.  It is also possible to split your domain.lisp file in multiple files and ensure they're all loaded.  In order to load a second file, you could use `read-domain-file` in your domain.lisp.  It understands lisp files and json files.
 
     (read-domain-file "my-main-domain.lisp")
     (read-domain-file "my-other-domain.lisp")
-
-## High-level questions
-
-This component is in use in a great deal of mu.semte.ch stacks.  A high-level picture as to why we built this component, and how it fits in the architecture, is suiting.
-
-### Why this component?
-
-The idea of mu-cl-resources is to provide an API which can easily be consumed by frontend applications.  The most common calls which a backend offers are repetitive and boring to implement.  Good developers should not be bothered with these boring details.  Instead, a declarative configuration can get rid of all of this.
-
-Furthermore, the wide reuse of this component provides us with a rich shared code-base.  The wide use of the code-base allows us to unlock an enormous amount of shared value by implementing small features in this codebase.  On the flipside, we should take great care that this repository does not get out of hand, as that may impact many applications.
-
-## Is this a microservice?
-
-Much of the code needed to implement this component was written specifically for this component.  It can be argued that this component is therefore not a typical microservice component.  We would argue differently.
-
-From a consumer's perspective, the configuration supplied of mu-cl-resources is the relevant portion of this service.  The API which is offered may be broad, but the configuration to maintain is comparatively small.  As the consumer has a good overview of the code necessary to configure this service, this could be considered a microservice from the consumer's perspective.
-
-From the developer's perspective things may look different.  It is clear that mu-cl-resources quite a broad code base.  Replacing it with other components has proven to be more expensive than expected.  Although this holds, many of the used functions could (and should) be abstracted into separate libraries over time.  Furthermore, we expect a similar code-base to work in different languages, although more code may need to be written.

--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ Since it is common for a mu.semte.ch project to contain mu-cl-resources, the def
 ### Introduction to a configuration through domain.lisp
 This service is driven from the domain.lisp file which you should adapt to describe your domain.  In this section we briefly describe how everything is wired together, and how you can quickly get an API up and running.
 
-mu-cl-resources is driven from the domain.lisp file.  This file describes the connection between the JSONAPI and the semantic model.  Secondly, there is the repository.lisp file, in which you can define new prefixes to shorten your domain description.  This repository contains an example of both files in the configuration folder.
+mu-cl-resources is driven from the domain.lisp file.  This file describes the connection between the JSONAPI and the semantic model.  Secondly, there is the repository.lisp file, in which you can define new prefixes to shorten your domain description.  This repository contains an example of both files in the examples folder.
 
 #### /configuration/domain.lisp
 
-The domain.lisp contains resource definitions for each file in the application.  These resource definitions provide a three-way connection:
+The domain.lisp contains resource definitions for each resource type in the application.  These resource definitions provide a three-way connection:
 
   - It names things to make connections within the domain.lisp file
   - It describes the properties as seen through the json api
   - It describes the semantic model used in order to implement the json api
 
-Each resource definition is a combination of these three views.  Let us assume an exmaple using [foaf](http://xmlns.com/foaf/0.1/).  In our example, we will model a Person, having one or more online accounts.  This model can be vizualised using [WebVOWL](http://visualdataweb.de/webvowl/#).
+Each resource definition is a combination of these three views.  Let us assume an example using [foaf](http://xmlns.com/foaf/0.1/).  In our example, we will model a Person, having one or more online accounts.  This model can be vizualised using [WebVOWL](http://visualdataweb.de/webvowl/#).
 
 Intermezzo: mu-cl-resources is mainly configured in lisp.  Lisp uses parens () for grouping content.  If a paren is followed by a word, that word tends to indicate the content of the group.  If there is no word, it tends to be a list.  Other characters, like the backtick (`) or the comma (,) are best copied from examples.
 
@@ -63,10 +63,11 @@ A simple definition of a person uses the foaf vocabulary to write the person and
 
   - *Line 1* contains `define-resource person`, which indicates that we'll create a new endpoint which we will name `person` in this file.  It is most customary to use a singular name for this name.
   - *Line 2* specifies that the RDF class to which the person belongs in the triplestore is [foaf:Person](http://xmlns.com/foaf/0.1/Person).
-  - *Line 3* specifies a singular property of the person.  The JSONAPI will assume content of type `string` is stored in the json key `data.attributes.name` (because of `:name`).  This value is connected to our resource in the triplestore by the perdicate [foaf:name](http://xmlns.com/foaf/0.1/name).  Note that this word may contain dashes, but not capitals (capitals are ignored).
-  - *Line 4* indicates the URI to use in the triplestore when we create new resources of this type.  The supplied url is postfixed with a UUID.  Line 5 specifies the endpoint on which we can list/create/update our resource.  In our case, requests to `/people` are mapped to this resource.
+  - *Line 3* specifies a singular property of the person.  The JSONAPI will assume content of type `string` is stored in the json key `data.attributes.name` (because of `:name`).  This value is connected to our resource in the triplestore by the predicate [foaf:name](http://xmlns.com/foaf/0.1/name).  Note that this word may contain dashes, but not capitals (capitals are ignored).
+  - *Line 4* indicates the URI to use in the triplestore when we create new resources of this type.  The supplied url is postfixed with a UUID.
+  - *Line 5* specifies the endpoint on which we can list/create/update our resource.  In our case, requests to `/people` are mapped to this resource.
 
-Assuming the foaf prefix is defined, we can make this example slightly easier to read.  Note the use of `s-prefix`.
+Assuming the foaf `prefix` is defined, we can make this example slightly easier to read.  Note the use of `s-prefix`.
 
     (define-resource person ()
       :class (s-prefix "foaf:Person")
@@ -174,9 +175,274 @@ The complete mu-cl-resources instance, a specific resource, as well as a propert
   - *property options:* Symbols following the definition of a single property may give mu-cl-resources extra information on how the property will be used.
 
 ### Introduction to a configuration through domain.json
+mu-cl-resources is driven from the domain.json file.  This file describes the connection between the JSONAPI and the semantic model.   In this section we briefly describe how everything is wired together, and how you can quickly get an API up and running. This repository contains an example file in the examples folder.
+
+
 #### /configuration/domain.json
+The domain.lisp contains resource definitions for each resource type in the application.  These resource definitions provide a three-way connection:
+
+  - It names things to make connections within the domain.lisp file
+  - It describes the properties as seen through the json api
+  - It describes the semantic model used in order to implement the json api
+
+Each resource definition is a combination of these three views.  Let us assume an example using [foaf](http://xmlns.com/foaf/0.1/).  In our example, we will model a Person, having one or more online accounts.  This model can be vizualised using [WebVOWL](http://visualdataweb.de/webvowl/#).
+
+```javascript
+{
+  "resources": {
+    "people": {
+      "name": "person",
+      "class": "http://xmlns.com/foaf/0.1/Person",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "http://xmlns.com/foaf/0.1/name"
+        }
+      }
+      "new-resource-base": "https://my-application.com/people/"
+    }
+  }
+}
+```
+
+A simple definition of a person uses the foaf vocabulary to write the person and the person name.
+
+  - *Line 2* specifies the endpoint on which we can list/create/update our resource.  In our case, requests to `/people` are mapped to this resource.
+  - *Line 3* contains the name `person` we will use to reference the resource in this file.  It is most customary to use a singular name for this name.
+  - *Line 4* specifies that the RDF class to which the person belongs in the triplestore is [foaf:Person](http://xmlns.com/foaf/0.1/Person).
+  - *Line 5-10* specifies an attribute of the person.  The JSONAPI will assume content of type `string` is stored in the json key `data.attributes.name` (because of `name` as attribute key).  This value is connected to our resource in the triplestore by the predicate [foaf:name](http://xmlns.com/foaf/0.1/name).  Note that the attribute key may contain dashes, but not capitals (capitals are ignored).
+  - *Line 11* indicates the URI to use in the triplestore when we create new resources of this type.  The supplied url is postfixed with a UUID.
+
+Assuming the `foaf` prefix is defined, we can make this example slightly easier to read.
+
+```javascript
+{
+  "prefixes": {
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "resources": {
+    "people": {
+      "name": "person",
+      "class": "foaf:Person",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:name"
+        }
+      }
+      "new-resource-base": "https://my-application.com/people/"
+    }
+  }
+}
+```
+
+This code sample implements the same functionality as the example above, yet it is easier on the eyes.
+
+We can insert multiple attributes if desired. We can update our example to also contain the age of the person, expressed as a number.
+
+```javascript
+{
+  "prefixes": {
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "resources": {
+    "people": {
+      "name": "person",
+      "class": "foaf:Person",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:name"
+        },
+        "age": {
+          "type": "number",
+          "predicate": "foaf:age"
+        }
+      }
+      "new-resource-base": "https://my-application.com/people/"
+    }
+  }
+}
+```
+
+With this minor change, our person supports the name and age attributes.
+
+Most resources link to other resources.  Let's first define a second resouce, an [OnlineAccount](http://xmlns.com/foaf/0.1/OnlineAccount).
+
+```javascript
+{
+  "prefixes": {
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "resources": {
+    "people": { ... },
+    "accounts": {
+      "name": "account",
+      "class": "foaf:OnlineAccount",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:accountName"
+        }
+      }
+      "new-resource-base": "https://my-application.com/accounts/"
+    }
+  }
+}
+```
+
+The definition of this `account` resource is very similar to that of the `person` resource.  How do we link a person to an account?  Assuming the person has many accounts, we link by defining a `relationships` block on the `person` resource.
+
+
+```javascript
+{
+  ...
+  "resources": {
+    "people": {
+      "name": "person",
+      "class": "foaf:Person",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:name"
+        },
+        "age": {
+          "type": "number",
+          "predicate": "foaf:age"
+        }
+      },
+      "relationships": {
+        "accounts": {
+          "predicate": "foaf:account",
+          "target": "account",
+          "cardinality": "many"
+        }
+      }
+      "new-resource-base": "https://my-application.com/people/"
+    },
+    "accounts": {
+      "name": "account",
+      "class": "foaf:OnlineAccount",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:accountName"
+        }
+      }
+      "new-resource-base": "https://my-application.com/accounts/"
+    }
+  }
+}
+```
+
+The `relationships` object specifies that a `person` may link to many resources of target type `account`.  In the triplestore, the link can be found by following the [foaf:account](http://xmlns.com/foaf/0.1/account) predicate, originating from the person's URI.  This relationship is exposed to the JSON API by using the relationship name "accounts".  Hence a GET to `/people/42/accounts` would yield the accounts of the person with UUID 42.
+
+How about getting the person which links to this account.  There is only a single person connected to an account.  Hence we can specify a relationship with cardinality `"one"` on the `account` resource.  In the semantic model of the triplestore, the relationship uses the [foaf:account](http://xmlns.com/foaf/0.1/account) property going from the person to the account.  Finding the person for an account therefore means we have to follow the same relationship in the other direction.  We can add the property `"inverse": true` to any relationship to make the semantic model follow the inverse arrow.  Here, the key in the json body will be `owner` rather than person.
+
+```javascript
+{
+  ...
+  "resources": {
+    "people": { ... },
+    "accounts": {
+      "name": "account",
+      "class": "foaf:OnlineAccount",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:accountName"
+        }
+      },
+      "relationships": {
+        "owner": {
+          "predicate": "foaf:account",
+          "target": "person",
+          "cardinality": "one",
+          "inverse": true
+        }
+      }
+      "new-resource-base": "https://my-application.com/accounts/"
+    }
+  }
+}
+```
+
+
+The complete setup of our user and account looks as follows:
+
+```javascript
+{
+  "prefixes": {
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "resources": {
+    "people": {
+      "name": "person",
+      "class": "foaf:Person",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:name"
+        },
+        "age": {
+          "type": "number",
+          "predicate": "foaf:age"
+        }
+      },
+      "relationships": {
+        "accounts": {
+          "predicate": "foaf:account",
+          "target": "account",
+          "cardinality": "many"
+        }
+      }
+      "new-resource-base": "https://my-application.com/people/"
+    },
+    "accounts": {
+      "name": "account",
+      "class": "foaf:OnlineAccount",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:accountName"
+        }
+      },
+      "relationships": {
+        "owner": {
+          "predicate": "foaf:account",
+          "target": "person",
+          "cardinality": "one",
+          "inverse": true
+        }
+      }
+      "new-resource-base": "https://my-application.com/accounts/"
+    }
+  }
+}
+```
+
 #### Resulting API
+We intend to support the full spec of [JSONAPI](http://jsonapi.org).  Support for this API comes out of the box with frameworks such as [ember-data](https://github.com/emberjs/data).  Most of what you read there will work, errors being a notable exception.  Here, we list some common calls which you could execute using the resources specified above.
+
+  - `# GET /people`
+  - `# GET /people/0b29a57a-d324-4302-9c92-61958e4cf250/accounts`
+  - `# GET /people?filter=John`
+  - `# GET /people?filter[age]=42`
+  - `# GET /people?include=accounts`
+  - `# GET /people?filter[:exact:name]=John%20Doe`
+  - `# GET /people?sort=age`
+  - `# GET /accounts?sort=-person.age`
+
+  - `# POST /people/0b29a57a-d324-4302-9c92-61958e4cf250`
+  - `# PATCH /people/0b29a57a-d324-4302-9c92-61958e4cf250`
+  - `# PATCH /people/0b29a57a-d324-4302-9c92-61958e4cf250/relationships/accounts`
+  - `# DELETE /people/0b29a57a-d324-4302-9c92-61958e4cf250/relationships/accounts`
+  - `# DELETE /people/0b29a57a-d324-4302-9c92-61958e4cf250`
+
+More information on each of these calls can be found throughout this document.
+
 #### More configuration options
+Configuration of the complete mu-cl-resource instance can only be done using a configuration file in Lisp.
 
 ## Reference
 ### Defining resources in Lisp

--- a/examples/domain.json
+++ b/examples/domain.json
@@ -1,0 +1,69 @@
+{
+  "version": "0.1",
+  "prefixes": {
+    "ext": "http://mu.semte.ch/vocabularies/ext/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "resources": {
+    "catalogs": {
+      "class": "dcat:Catalog",
+      "attributes": {
+        "title": { "type": "string", "predicate": "dct:title" }
+      },
+      "relationships": {
+        "datasets": {
+          "target": "datasets",
+          "predicate": "dcat:dataset",
+          "cardinality": "many"
+        }
+      },
+      "new-resource-base": "http://webcat.tmp.semte.ch/catalogs/"
+    },
+    "datasets": {
+      "class": "dcat:Dataset",
+      "attributes": {
+        "title": { "type": "string", "predicate": "dct:title" },
+        "description": { "type": "string", "predicate": "dct:description" }
+      },
+      "relationships": {
+        "catalog": {
+          "target": "catalogs",
+          "predicate": "dcat:dataset",
+          "inverse": true,
+          "cardinality": "one"
+        },
+        "themes": {
+          "target": "themes",
+          "predicate": "dcat:theme",
+          "cardinality": "many"
+        }
+      },
+      "new-resource-base": "http://webcat.tmp.semte.ch/datasets/"
+    },
+    "distributions": {
+      "class": "dcat:Distribution",
+      "attributes": {
+        "title": { "type": "string", "predicate": "dct:title" },
+        "access-url": { "type": "url", "predicate": "dcat:accessURL" }
+      },
+      "new-resource-base": "http://webcat.tmp.semte.ch/distributions/"
+    },
+    "themes": {
+      "class": "dcat:Theme",
+      "attributes": {
+        "pref-label": { "type": "string", "predicate": "skos:prefLabel" }
+      },
+      "relationships": {
+        "datasets": {
+          "target": "datasets",
+          "predicate": "dcat:theme",
+          "inverse": true,
+          "cardinality": "many"
+        }
+      },
+      "new-resource-base": "http://webcat.tmp.semte.ch/themes/"
+    }
+  }
+}

--- a/examples/domain.lisp
+++ b/examples/domain.lisp
@@ -1,0 +1,64 @@
+(in-package :mu-cl-resources)
+
+;;;;
+;; NOTE
+;; docker-compose stop; docker-compose rm; docker-compose up
+;; after altering this file.
+
+;; Describe your resources here
+
+;; The general structure could be described like this:
+;;
+;; (define-resource <name-used-in-this-file> ()
+;;   :class <class-of-resource-in-triplestore>
+;;   :properties `((<json-property-name-one> <type-one> ,<triplestore-relation-one>)
+;;                 (<json-property-name-two> <type-two> ,<triplestore-relation-two>>))
+;;   :has-many `((<name-of-an-object> :via ,<triplestore-relation-to-objects>
+;;                                    :as "<json-relation-property>")
+;;               (<name-of-an-object> :via ,<triplestore-relation-from-objects>
+;;                                    :inverse t ; follow relation in other direction
+;;                                    :as "<json-relation-property>"))
+;;   :has-one `((<name-of-an-object :via ,<triplestore-relation-to-object>
+;;                                  :as "<json-relation-property>")
+;;              (<name-of-an-object :via ,<triplestore-relation-from-object>
+;;                                  :as "<json-relation-property>"))
+;;   :resource-base (s-url "<string-to-which-uuid-will-be-appended-for-uri-of-new-items-in-triplestore>")
+;;   :on-path "<url-path-on-which-this-resource-is-available>")
+
+
+;; An example setup with a catalog, dataset:
+(define-resource catalog ()
+  :class (s-prefix "dcat:Catalog")
+  :properties `((:title :string ,(s-prefix "dct:title")))
+  :has-many `((dataset :via ,(s-prefix "dcat:dataset")
+                       :as "datasets"))
+  :resource-base (s-url "http://webcat.tmp.semte.ch/catalogs/")
+  :on-path "catalogs")
+
+(define-resource dataset ()
+  :class (s-prefix "dcat:Dataset")
+  :properties `((:title :string ,(s-prefix "dct:title"))
+                (:description :string ,(s-prefix "dct:description")))
+  :has-one `((catalog :via ,(s-prefix "dcat:dataset")
+                      :inverse t
+                      :as "catalog"))
+  :has-many `((theme :via ,(s-prefix "dcat:theme")
+                     :as "themes"))
+  :resource-base (s-url "http://webcat.tmp.semte.ch/datasets/")
+  :on-path "datasets")
+
+(define-resource distribution ()
+  :class (s-prefix "dcat:Distribution")
+  :properties `((:title :string ,(s-prefix "dct:title"))
+                (:access-url :url ,(s-prefix "dcat:accessURL")))
+  :resource-base (s-url "http://webcat.tmp.semte.ch/distributions/")
+  :on-path "distributions")
+
+(define-resource theme ()
+  :class (s-prefix "dcat:Theme")
+  :properties `((:pref-label :string ,(s-prefix "skos:prefLabel")))
+  :has-many `((dataset :via ,(s-prefix "dcat:theme")
+                       :inverse t
+                       :as "datasets"))
+  :resource-base (s-url "http://webcat.tmp.semte.ch/themes/")
+  :on-path "themes")

--- a/examples/repository.lisp
+++ b/examples/repository.lisp
@@ -1,0 +1,37 @@
+(in-package :mu-cl-resources)
+
+;;;;
+;; NOTE
+;; docker-compose stop; docker-compose rm; docker-compose up
+;; after altering this file.
+
+
+;;;;
+;; Describe the prefixes which you'll use in the domain file here.
+;; This is a short-form which allows you to write, for example,
+;; (s-url "http://purl.org/dc/terms/title")
+;; as (s-prefix "dct:title")
+
+;; (add-prefix "dct" "http://purl.org/dc/terms/")
+
+
+;;;;;
+;; The following is the commented out version of those used in the
+;; commented out domain.lisp.
+
+;; (add-prefix "dcat" "http://www.w3.org/ns/dcat#")
+;; (add-prefix "dct" "http://purl.org/dc/terms/")
+;; (add-prefix "skos" "http://www.w3.org/2004/02/skos/core#")
+
+
+;;;;;
+;; You can use the muext: prefix when you're still searching for
+;; the right predicates during development.  This should *not* be
+;; used to publish any data under.  It's merely a prefix of which
+;; the mu.semte.ch organisation indicates that it will not be used
+;; by them and that it shouldn't be used for permanent URIs.
+
+(add-prefix "ext" "http://mu.semte.ch/vocabularies/ext/")
+(add-prefix "dcat" "http://www.w3.org/ns/dcat#")
+(add-prefix "dct" "http://purl.org/dc/terms/")
+(add-prefix "skos" "http://www.w3.org/2004/02/skos/core#")


### PR DESCRIPTION
This PR will receive various commits to update the documentation for the domain.json format.

Steps in this PR:

- [x] Update introduction
- [x] Add example domain.lisp and example domain.json file
- [x] Write "How-to: Combining domain.lisp and domain.json" and update name in introduction
- [x] Update naming of sections to match new documentation guidelines
- [x] Create new introduction for domain.json, copied from domain and repositories.lisp
- [x] Create new normative section of domain specification using domain.json formatting
- [x] Update section on API to include domain.json and domain.lisp format