### PR TITLE
Add cache key for all (super) classes of resource when caching an inverse relationship

### DIFF
--- a/framework/support.lisp
+++ b/framework/support.lisp
@@ -490,8 +490,9 @@ TEST is a function which receives the current sub-list, possibly out of order."
   (add-cache-key :uri (node-url item-spec)
                  :ld-relation (expanded-ld-relation relation))
   ;; for clearing of inverse relationships
-  (add-cache-key :ld-resource (expanded-ld-class (resource item-spec))
-                 :ld-relation (expanded-ld-relation relation)))
+  (dolist (super-resource (flattened-class-tree (resource item-spec)))
+    (add-cache-key :ld-resource (expanded-ld-class super-resource)
+                   :ld-relation (expanded-ld-relation relation))))
 
 (defun cache-clear-class (resource)
   "Clears the current class.


### PR DESCRIPTION
When caching an inverse relationship, we add a cache key `ld-resource: Class, ld-relation: relationship`.
When dealing with subclasses, this doesn't entirely work, because the cache keys set use the base classes, whereas the clear keys set when updating the relationship use the base class, which causes the cached call to never be invalidated.

This fixes that by setting the cache keys with all the classes, so the most derived class all the way through all the super classes, to ensure that when the clear key is set at update-time, any cached calls get invalidated.

This should fix #32 